### PR TITLE
fix: use correct regex for splitting value string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.sys.process._
 
 name := "simple-scala-generator"
 organization := "io.grhodes"
-version := "1.2.0"
+version := "1.3.0"
 
 scalaVersion := "2.12.13"
 

--- a/src/main/scala/io/grhodes/simple/codegen/BaseScalaCodegen.scala
+++ b/src/main/scala/io/grhodes/simple/codegen/BaseScalaCodegen.scala
@@ -132,7 +132,7 @@ abstract class BaseScalaCodegen extends AbstractScalaCodegen with CodegenConfig 
   }
 
   override def toEnumVarName(value: String, datatype: String): String = {
-    val split = value.split("[ -_]")
+    val split = value.split("[ _-]")
     val safeVal = if(split.nonEmpty) {
       split.map(_.capitalize).mkString
     } else {

--- a/src/test/scala/com/meetup/codegen/ModelEnumNamingTest.scala
+++ b/src/test/scala/com/meetup/codegen/ModelEnumNamingTest.scala
@@ -40,6 +40,11 @@ class ModelEnumNamingTest extends FunSpec with Matchers {
         name shouldBe "Number1"
       }
     }
+
+    it("should leave already camelized values as they are") {
+      val name = codeGen.toEnumVarName("HelloThere", "some_data_type")
+      name shouldBe "HelloThere"
+    }
   }
 
   describe("toEnumValue") {


### PR DESCRIPTION
In the original format, the string "HelloThere" would have been split into
("ello", "here") instead of ("Hello", "There").

This fix is needed to allow for CamelCase values to work